### PR TITLE
Stupid change

### DIFF
--- a/botlog.py
+++ b/botlog.py
@@ -1,6 +1,6 @@
 import pickle
 async def botlog(args, bot, channel):
-    if args=="logchannel":
+    if args=="logchannel ":
         msgauth1 = message.author
         await channel.send("What channel would you like log messages to be posted in?")
         botlogchannel = await channel.history().find(lambda m: m.author.id == msgauth1)


### PR DESCRIPTION
First of all this will be commit #69
Second of all, this change is stupid
when making sure that every time a command is called with no arguments does not crash hal, I made it add a space to the end of every command with an argument. oops.
botlog is the only command where is checks if the arguments are exactly what they need to be and doesn't use split, so this is the only file that needs modification.