### PR TITLE
Allow ban to work on multiple users at once

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,32 +65,33 @@ async def ban(ctx, args):
     """'Bans' a user."""
     converter = MemberConverter()
     converter2 = RoleConverter()
-    user = await converter.convert(ctx, args)
     banroleids = [738456842707140700, 742128809129803806, 742128992286670910, 742129191277035590]
-    userbanroles = []
-    for bancycle in banroleids:
-        for x in user.roles:
-            if x.id == bancycle:
-                userbanroles.append(x.id)
-        if (not bancycle in userbanroles):
-            break
-    if len(userbanroles) != 0:
-        x = userbanroles[-1]
-    else:
-        x = 0
-    print(userbanroles)
-    print(x)
-    if x == 0:
-        y = await converter2.convert(ctx, "738456842707140700")
-        await user.add_roles(y)
-        await ctx.send("Ban role " + str(y) + " successfully added to user " + args)
-    elif x != 742129191277035590:
-        y = await converter2.convert(ctx, str(banroleids[banroleids.index(x) + 1]))
-        await user.add_roles(y)
-        [await user.remove_roles(thisshouldntbeplural) for thisshouldntbeplural in ([await converter2.convert(ctx, str(banroleids[z])) for z in range(0,banroleids.index(x)+1)])]
-        await ctx.send("Ban role " + str(y) + " successfully added to user " + args)
-    else:
-        await ctx.send("User " + args + " has all the banned roles already.")
+    for cycl in args.split():
+        user = await converter.convert(ctx, args[cycl])
+        userbanroles = []
+        for bancycle in banroleids:
+            for x in user.roles:
+                if x.id == bancycle:
+                    userbanroles.append(x.id)
+            if (not bancycle in userbanroles):
+                break
+        if len(userbanroles) != 0:
+            x = userbanroles[-1]
+        else:
+            x = 0
+        print(userbanroles)
+        print(x)
+        if x == 0:
+            y = await converter2.convert(ctx, "738456842707140700")
+            await user.add_roles(y)
+            await ctx.send("Ban role " + str(y) + " successfully added to user " + args[cycl])
+        elif x != 742129191277035590:
+            y = await converter2.convert(ctx, str(banroleids[banroleids.index(x) + 1]))
+            await user.add_roles(y)
+            [await user.remove_roles(thisshouldntbeplural) for thisshouldntbeplural in ([await converter2.convert(ctx, str(banroleids[z])) for z in range(0,banroleids.index(x)+1)])]
+            await ctx.send("Ban role " + str(y) + " successfully added to user " + args[cycl])
+        else:
+            await ctx.send("User " + args[cycl] + " has all the banned roles already.")
 
 
 bot.run(open("token").read())


### PR DESCRIPTION
I have a history of making completely broken pull requests, but this one should theoretically be trivial to implement. I mean, I still managed to type "cyc;" instead of "cycl" while making this, but I did fix that.