### PR TITLE
make //ban slightly less conic

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -22,7 +22,7 @@ class Mod(commands.Cog):
         `//ban <user> <reason>`"""
         user = await MemberConverter().convert(ctx, args[0])
         try:
-            await user.ban(reason=args[1])
+            await user.ban(reason=' '.join(args[1:]))
         except IndexError:
             await user.ban()
         await ctx.send(user.mention + " has been banned.")


### PR DESCRIPTION
this makes the full ban message work without quotation marks assuming I got python's cringe syntax correct